### PR TITLE
[DOCS] Correct ignore_row_if doc in ExpectColumnPairValuesToBeEqual

### DIFF
--- a/great_expectations/expectations/core/expect_column_pair_values_to_be_equal.py
+++ b/great_expectations/expectations/core/expect_column_pair_values_to_be_equal.py
@@ -66,7 +66,7 @@ class ExpectColumnPairValuesToBeEqual(ColumnPairMapExpectation):
     Other Parameters:
         ignore_row_if (str): \
             "both_values_are_missing", "either_value_is_missing", "neither" \
-            {IGNORE_ROW_IF_DESCRIPTION} Default "neither".
+            {IGNORE_ROW_IF_DESCRIPTION} Default "both_values_are_missing".
         mostly (None or a float between 0 and 1): \
             {MOSTLY_DESCRIPTION} \
             For more detail, see [mostly](https://docs.greatexpectations.io/docs/reference/expectations/standard_arguments/#mostly). Default 1.


### PR DESCRIPTION
In the code, `ignore_row_if` parameter has _both_values_are_missing_ as default, although the docs says it is _neither_

`    ignore_row_if: Literal["both_values_are_missing", "either_value_is_missing", "neither"] = (
        pydantic.Field(default="both_values_are_missing", description=IGNORE_ROW_IF_DESCRIPTION)
    )`

- [ ] Description of PR changes above includes a link to [an existing GitHub issue](https://github.com/great-expectations/great_expectations/issues)
- [x] PR title is prefixed with one of: [BUGFIX], [FEATURE], [DOCS], [MAINTENANCE], [CONTRIB]
- [x] Code is linted - run `invoke lint` (uses `ruff format` + `ruff check`)
- [x] Appropriate tests and docs have been updated

For more information about contributing, see [Contribute](https://docs.greatexpectations.io/docs/contributing/contributing_checklist).

After you submit your PR, keep the page open and **monitor the statuses of the various checks made by our continuous integration process at the bottom of the page. Please fix any issues that come up** and [reach out on Slack](https://greatexpectations.io/slack) if you need help. Thanks for contributing!
